### PR TITLE
Small hotfix to fix path of ecbundle script after upstream update

### DIFF
--- a/cloudsc-bundle
+++ b/cloudsc-bundle
@@ -36,7 +36,7 @@ if ! command_exists ${BOOTSTRAPPED} ; then
         git clone ${BITBUCKET}/escape/ecbundle.git ${BUNDLE_DIR}/ecbundle
         ( cd ${BUNDLE_DIR}/ecbundle && git checkout ${ecbundle_VERSION} )
     fi
-    export PATH=${BUNDLE_DIR}/ecbundle:${PATH}
+    export PATH=${BUNDLE_DIR}/ecbundle/bin:${PATH}
 fi
 
 ${BOOTSTRAPPED} "$@"


### PR DESCRIPTION
Same fix as in the internal CLOUDSC repo recently.