### PR TITLE
Loki: Transformation pipeline definitions in config files

### DIFF
--- a/arch/ecmwf/hpc2020/nvhpc/22.11/env.sh
+++ b/arch/ecmwf/hpc2020/nvhpc/22.11/env.sh
@@ -1,0 +1,52 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# Source me to get the correct configure/build/run environment
+
+# Store tracing and disable (module is *way* too verbose)
+{ tracing_=${-//[^x]/}; set +x; } 2>/dev/null
+
+module_load() {
+  echo "+ module load $1"
+  module load $1
+}
+module_unload() {
+  echo "+ module unload $1"
+  module unload $1
+}
+
+# Unload all modules to be certain
+module_unload nvidia
+module_unload intel-mpi
+module_unload openmpi
+module_unload hpcx-openmpi
+module_unload boost
+module_unload hdf5
+module_unload cmake
+module_unload python3
+module_unload java
+
+# Load modules
+module_load prgenv/nvidia
+module_load nvidia/22.11
+module_load hpcx-openmpi/2.10.0
+# module_load boost/1.71.0
+module_load hdf5/1.10.6
+module_load cmake/3.25.2
+module_load python3/3.10.10-01
+module_load java/11.0.6
+
+# Increase stack size to maximum
+ulimit -S -s unlimited
+
+set -x
+
+# Restore tracing to stored setting
+{ if [[ -n "$tracing_" ]]; then set -x; else set +x; fi } 2>/dev/null
+
+export ECBUILD_TOOLCHAIN="./toolchain.cmake"

--- a/arch/ecmwf/hpc2020/nvhpc/22.11/toolchain.cmake
+++ b/arch/ecmwf/hpc2020/nvhpc/22.11/toolchain.cmake
@@ -1,0 +1,1 @@
+../../../../toolchains/ecmwf-hpc2020-nvhpc.cmake

--- a/arch/toolchains/ecmwf-hpc2020-nvhpc.cmake
+++ b/arch/toolchains/ecmwf-hpc2020-nvhpc.cmake
@@ -11,29 +11,41 @@
 ####################################################################
 
 set( ECBUILD_FIND_MPI ON )
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-set(CMAKE_C_COMPILER nvc)
-set(CMAKE_CXX_COMPILER nvc++)
-set(CMAKE_Fortran_COMPILER nvfortran)
 
 ####################################################################
 # OpenMP FLAGS
 ####################################################################
 
-# Note that we do not support device offload via OpenMP (yet!)
-set( OpenMP_C_FLAGS             "-mp -mp=bind,allcores,numa" )
-set( OpenMP_CXX_FLAGS           "-mp -mp=bind,allcores,numa" )
-set( OpenMP_Fortran_FLAGS       "-mp -mp=bind,allcores,numa" )
+# Note: OpenMP_Fortran_FLAGS gets overwritten by the FindOpenMP module
+# unless its stored as a cache variable
+set( OpenMP_Fortran_FLAGS   "-mp -mp=gpu,bind,allcores,numa" CACHE STRING "" )
+
+# Note: OpenMP_C_FLAGS and OpenMP_C_LIB_NAMES have to be provided _both_ to
+# keep FindOpenMP from overwriting the FLAGS variable (the cache entry alone
+# doesn't have any effect here as the module uses FORCE to overwrite the
+# existing value)
+set( OpenMP_C_FLAGS         "-mp -mp=bind,allcores,numa" CACHE STRING "" )
+set( OpenMP_C_LIB_NAMES     "acchost" CACHE STRING "")
 
 ####################################################################
 # OpenAcc FLAGS
 ####################################################################
 
-set( OpenACC_Fortran_FLAGS "-acc=gpu -gpu=lineinfo,fastmath,rdc" CACHE STRING "" )
-
+# Importantly, enable `gvmode` to remove the limit of 32 vector threads
+# per thread block
+# NB: We have to add `-mp` again to avoid undefined symbols during linking
+# (smells like an Nvidia bug)
+set( OpenACC_Fortran_FLAGS "-acc=gpu -mp=gpu -gpu=cc80,lineinfo,fastmath,gvmode" CACHE STRING "" )
 # Enable this to get more detailed compiler output
 # set( OpenACC_Fortran_FLAGS "${OpenACC_Fortran_FLAGS} -Minfo" )
+
+####################################################################
+# CUDA FLAGS
+####################################################################
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES 80)
+endif()
 
 ####################################################################
 # COMMON FLAGS

--- a/src/cloudsc2_ad_loki/CMakeLists.txt
+++ b/src/cloudsc2_ad_loki/CMakeLists.txt
@@ -89,11 +89,8 @@ if( HAVE_CLOUDSC2_AD_LOKI )
             cloudsc_driver_ad_loki_mod.F90
         MODE scc
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
-        DATA_OFFLOAD
-        REMOVE_OPENMP
         CPP
         DEFINITIONS
-            ${CLOUDSC_DEFINITIONS}
             CLOUDSC_GPU_TIMING
         FRONTEND ${LOKI_FRONTEND}
         SOURCES
@@ -149,11 +146,8 @@ if( HAVE_CLOUDSC2_AD_LOKI )
             cloudsc_driver_ad_loki_mod.F90
         MODE scc-hoist
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
-        DATA_OFFLOAD
-        REMOVE_OPENMP
         CPP
         DEFINITIONS
-            ${CLOUDSC_DEFINITIONS}
             CLOUDSC_GPU_TIMING
         FRONTEND ${LOKI_FRONTEND}
         SOURCES

--- a/src/cloudsc2_ad_loki/CMakeLists.txt
+++ b/src/cloudsc2_ad_loki/CMakeLists.txt
@@ -55,6 +55,10 @@ if( HAVE_CLOUDSC2_AD_LOKI )
             cloudsc2-common-lib
         DEFINITIONS ${CLOUDSC_DEFINITIONS}
     )
+    # Set specific module directory to avoid aliasing of .mod files
+    set_target_properties( dwarf-cloudsc2-ad-loki-idem
+        PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-idem
+    )
 
     ecbuild_add_test(
         TARGET dwarf-cloudsc2-ad-loki-idem-serial
@@ -109,6 +113,10 @@ if( HAVE_CLOUDSC2_AD_LOKI )
          LIBS
              cloudsc2-common-lib
          DEFINITIONS ${CLOUDSC_DEFINITIONS}
+     )
+     # Set specific module directory to avoid aliasing of .mod files
+     set_target_properties( dwarf-cloudsc2-ad-loki-scc
+         PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-scc
      )
 
      ecbuild_add_test(
@@ -165,6 +173,10 @@ if( HAVE_CLOUDSC2_AD_LOKI )
          LIBS
              cloudsc2-common-lib
          DEFINITIONS ${CLOUDSC_DEFINITIONS}
+     )
+     # Set specific module directory to avoid aliasing of .mod files
+     set_target_properties( dwarf-cloudsc2-ad-loki-scc-hoist
+         PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-scc-hoist
      )
 
      ecbuild_add_test(

--- a/src/cloudsc2_ad_loki/CMakeLists.txt
+++ b/src/cloudsc2_ad_loki/CMakeLists.txt
@@ -117,7 +117,7 @@ if( HAVE_CLOUDSC2_AD_LOKI )
      )
 
      ecbuild_add_test(
-         TARGET dwarf-cloudsc2-ad--loki-scc-serial
+         TARGET dwarf-cloudsc2-ad-loki-scc-serial
          COMMAND bin/dwarf-cloudsc2-ad-loki-scc
          ARGS
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../..
@@ -174,7 +174,7 @@ if( HAVE_CLOUDSC2_AD_LOKI )
      )
 
      ecbuild_add_test(
-         TARGET dwarf-cloudsc2-ad--loki-scc-hoist-serial
+         TARGET dwarf-cloudsc2-ad-loki-scc-hoist-serial
          COMMAND bin/dwarf-cloudsc2-ad-loki-scc-hoist
          ARGS
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../..

--- a/src/cloudsc2_ad_loki/cloudsc_loki.config
+++ b/src/cloudsc2_ad_loki/cloudsc_loki.config
@@ -34,3 +34,77 @@ disable = ['timer_mod', 'file_io_mod', 'foe*', 'fes*', 'falfaad']
 [dimensions.block_dim]
   size = 'NGPBLKS'
   index = 'IBL'
+
+
+# Define specific transformation settings
+# -------------------------------------------------------------------
+# The section configures the invididual steps of the transformation
+# pipelines. Importantly, it also defines the class name and Python
+# module that Transformation objecst will be instatiated from.
+[transformations]
+
+# A set of utility transformations
+# -------------------------------------------------------------------
+[transformations.Idem]
+  classname = 'IdemTransformation'
+  module = 'loki.transformations'
+
+
+# Loki-SCC family of transformations
+# -------------------------------------------------------------------
+# A set of transformation passes that transforms SIMD vectorisation
+# loops into SIMD-style loops for coalesced memory access on GPU.
+# It also contains passes that improve device memory handling on GPUs.
+[transformations.SCCVector]
+  classname = 'SCCVectorPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.SCCVector.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+[transformations.SCCHoist]
+  classname = 'SCCHoistPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.SCCHoist.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+# Housekeeping and other transformations
+# -------------------------------------------------------------------
+[transformations.DataOffload]
+  classname = 'DataOffloadTransformation'
+  module = 'loki.transformations'
+  options = { remove_openmp = true, claw_data_offload = false }
+
+
+[transformations.ModuleWrap]
+  classname = 'ModuleWrapTransformation'
+  module = 'loki.transformations.build_system'
+  options = { module_suffix = '_MOD' }
+
+
+[transformations.Dependency]
+  classname = 'DependencyTransformation'
+  module = 'loki.transformations.build_system'
+  options = { suffix = '_LOKI', module_suffix = '_MOD' }
+
+
+# Full transformation pipelines
+# -------------------------------------------------------------------
+# The entries below are mapped to the "mode" entry point in
+# loki-transform.py. The define the set of transformation and the
+# order in which they are applies to the complete call tree.
+[pipelines]
+
+[pipelines.idem]
+  transformations = ['Idem', 'ModuleWrap', 'Dependency']
+
+[pipelines.scc]
+  transformations = ['DataOffload', 'SCCVector', 'ModuleWrap', 'Dependency']
+
+[pipelines.scc-hoist]
+  transformations = ['DataOffload', 'SCCHoist', 'ModuleWrap', 'Dependency']

--- a/src/cloudsc2_nl_loki/CMakeLists.txt
+++ b/src/cloudsc2_nl_loki/CMakeLists.txt
@@ -51,6 +51,10 @@ if( HAVE_CLOUDSC2_NL_LOKI )
             cloudsc2-common-lib
         DEFINITIONS ${CLOUDSC_DEFINITIONS}
     )
+    # Set specific module directory to avoid aliasing of .mod files
+    set_target_properties( dwarf-cloudsc2-nl-loki-idem
+        PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-idem
+    )
 
     ecbuild_add_test(
         TARGET dwarf-cloudsc2-nl-loki-idem-serial
@@ -104,6 +108,10 @@ if( HAVE_CLOUDSC2_NL_LOKI )
         LIBS
             cloudsc2-common-lib
         DEFINITIONS ${CLOUDSC_DEFINITIONS}
+    )
+    # Set specific module directory to avoid aliasing of .mod files
+    set_target_properties( dwarf-cloudsc2-nl-loki-scc
+        PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-scc
     )
 
     ecbuild_add_test(
@@ -159,6 +167,10 @@ if( HAVE_CLOUDSC2_NL_LOKI )
         LIBS
             cloudsc2-common-lib
         DEFINITIONS ${CLOUDSC_DEFINITIONS}
+    )
+    # Set specific module directory to avoid aliasing of .mod files
+    set_target_properties( dwarf-cloudsc2-nl-loki-scc-hoist
+        PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-scc-hoist
     )
 
     ecbuild_add_test(

--- a/src/cloudsc2_nl_loki/CMakeLists.txt
+++ b/src/cloudsc2_nl_loki/CMakeLists.txt
@@ -84,12 +84,8 @@ if( HAVE_CLOUDSC2_NL_LOKI )
             cloudsc_driver_loki_mod.F90
         MODE scc
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
-        DIRECTIVE openacc
-        DATA_OFFLOAD
-        REMOVE_OPENMP
         CPP
         DEFINITIONS
-            ${CLOUDSC_DEFINE_STMT_FUNC}
             CLOUDSC_GPU_TIMING
         FRONTEND ${LOKI_FRONTEND}
         SOURCES
@@ -143,12 +139,8 @@ if( HAVE_CLOUDSC2_NL_LOKI )
             cloudsc_driver_loki_mod.F90
         MODE scc-hoist
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
-        DIRECTIVE openacc
-        DATA_OFFLOAD
-        REMOVE_OPENMP
         CPP
         DEFINITIONS
-            ${CLOUDSC_DEFINE_STMT_FUNC}
             CLOUDSC_GPU_TIMING
         FRONTEND ${LOKI_FRONTEND}
         SOURCES

--- a/src/cloudsc2_nl_loki/cloudsc_loki.config
+++ b/src/cloudsc2_nl_loki/cloudsc_loki.config
@@ -34,3 +34,77 @@ disable = ['timer_mod', 'file_io_mod', 'foe*']
 [dimensions.block_dim]
   size = 'NGPBLKS'
   index = 'IBL'
+
+
+# Define specific transformation settings
+# -------------------------------------------------------------------
+# The section configures the invididual steps of the transformation
+# pipelines. Importantly, it also defines the class name and Python
+# module that Transformation objecst will be instatiated from.
+[transformations]
+
+# A set of utility transformations
+# -------------------------------------------------------------------
+[transformations.Idem]
+  classname = 'IdemTransformation'
+  module = 'loki.transformations'
+
+
+# Loki-SCC family of transformations
+# -------------------------------------------------------------------
+# A set of transformation passes that transforms SIMD vectorisation
+# loops into SIMD-style loops for coalesced memory access on GPU.
+# It also contains passes that improve device memory handling on GPUs.
+[transformations.SCCVector]
+  classname = 'SCCVectorPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.SCCVector.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+[transformations.SCCHoist]
+  classname = 'SCCHoistPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.SCCHoist.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+# Housekeeping and other transformations
+# -------------------------------------------------------------------
+[transformations.DataOffload]
+  classname = 'DataOffloadTransformation'
+  module = 'loki.transformations'
+  options = { remove_openmp = true, claw_data_offload = false }
+
+
+[transformations.ModuleWrap]
+  classname = 'ModuleWrapTransformation'
+  module = 'loki.transformations.build_system'
+  options = { module_suffix = '_MOD' }
+
+
+[transformations.Dependency]
+  classname = 'DependencyTransformation'
+  module = 'loki.transformations.build_system'
+  options = { suffix = '_LOKI', module_suffix = '_MOD' }
+
+
+# Full transformation pipelines
+# -------------------------------------------------------------------
+# The entries below are mapped to the "mode" entry point in
+# loki-transform.py. The define the set of transformation and the
+# order in which they are applies to the complete call tree.
+[pipelines]
+
+[pipelines.idem]
+  transformations = ['Idem', 'ModuleWrap', 'Dependency']
+
+[pipelines.scc]
+  transformations = ['DataOffload', 'SCCVector', 'ModuleWrap', 'Dependency']
+
+[pipelines.scc-hoist]
+  transformations = ['DataOffload', 'SCCHoist', 'ModuleWrap', 'Dependency']

--- a/src/cloudsc2_tl_loki/CMakeLists.txt
+++ b/src/cloudsc2_tl_loki/CMakeLists.txt
@@ -90,11 +90,8 @@ if( HAVE_CLOUDSC2_TL_LOKI )
             cloudsc_driver_tl_loki_mod.F90
         MODE scc
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
-        DATA_OFFLOAD
-        REMOVE_OPENMP
         CPP
         DEFINITIONS
-            ${CLOUDSC_DEFINITIONS}
             CLOUDSC_GPU_TIMING
         FRONTEND ${LOKI_FRONTEND}
         SOURCES
@@ -152,11 +149,8 @@ if( HAVE_CLOUDSC2_TL_LOKI )
             cloudsc_driver_tl_loki_mod.F90
         MODE scc-hoist
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
-        DATA_OFFLOAD
-        REMOVE_OPENMP
         CPP
         DEFINITIONS
-            ${CLOUDSC_DEFINITIONS}
             CLOUDSC_GPU_TIMING
         FRONTEND ${LOKI_FRONTEND}
         SOURCES

--- a/src/cloudsc2_tl_loki/CMakeLists.txt
+++ b/src/cloudsc2_tl_loki/CMakeLists.txt
@@ -55,6 +55,10 @@ if( HAVE_CLOUDSC2_TL_LOKI )
             cloudsc2-common-lib
         DEFINITIONS ${CLOUDSC_DEFINITIONS}
     )
+    # Set specific module directory to avoid aliasing of .mod files
+    set_target_properties( dwarf-cloudsc2-tl-loki-idem
+        PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-idem
+    )
 
     ecbuild_add_test(
         TARGET dwarf-cloudsc2-tl-loki-idem-serial
@@ -111,6 +115,10 @@ if( HAVE_CLOUDSC2_TL_LOKI )
           LIBS
               cloudsc2-common-lib
           DEFINITIONS ${CLOUDSC_DEFINITIONS}
+      )
+      # Set specific module directory to avoid aliasing of .mod files
+      set_target_properties( dwarf-cloudsc2-tl-loki-scc
+          PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-scc
       )
 
       ecbuild_add_test(
@@ -169,6 +177,10 @@ if( HAVE_CLOUDSC2_TL_LOKI )
          LIBS
              cloudsc2-common-lib
          DEFINITIONS ${CLOUDSC_DEFINITIONS}
+     )
+     # Set specific module directory to avoid aliasing of .mod files
+     set_target_properties( dwarf-cloudsc2-tl-loki-scc-hoist
+         PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/loki-scc-hoist
      )
 
      ecbuild_add_test(

--- a/src/cloudsc2_tl_loki/cloudsc_loki.config
+++ b/src/cloudsc2_tl_loki/cloudsc_loki.config
@@ -34,3 +34,77 @@ disable = ['timer_mod', 'file_io_mod', 'error_mod', 'foe*', 'fes*']
 [dimensions.block_dim]
   size = 'NGPBLKS'
   index = 'IBL'
+
+
+# Define specific transformation settings
+# -------------------------------------------------------------------
+# The section configures the invididual steps of the transformation
+# pipelines. Importantly, it also defines the class name and Python
+# module that Transformation objecst will be instatiated from.
+[transformations]
+
+# A set of utility transformations
+# -------------------------------------------------------------------
+[transformations.Idem]
+  classname = 'IdemTransformation'
+  module = 'loki.transformations'
+
+
+# Loki-SCC family of transformations
+# -------------------------------------------------------------------
+# A set of transformation passes that transforms SIMD vectorisation
+# loops into SIMD-style loops for coalesced memory access on GPU.
+# It also contains passes that improve device memory handling on GPUs.
+[transformations.SCCVector]
+  classname = 'SCCVectorPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.SCCVector.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+[transformations.SCCHoist]
+  classname = 'SCCHoistPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.SCCHoist.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+# Housekeeping and other transformations
+# -------------------------------------------------------------------
+[transformations.DataOffload]
+  classname = 'DataOffloadTransformation'
+  module = 'loki.transformations'
+  options = { remove_openmp = true, claw_data_offload = false }
+
+
+[transformations.ModuleWrap]
+  classname = 'ModuleWrapTransformation'
+  module = 'loki.transformations.build_system'
+  options = { module_suffix = '_MOD' }
+
+
+[transformations.Dependency]
+  classname = 'DependencyTransformation'
+  module = 'loki.transformations.build_system'
+  options = { suffix = '_LOKI', module_suffix = '_MOD' }
+
+
+# Full transformation pipelines
+# -------------------------------------------------------------------
+# The entries below are mapped to the "mode" entry point in
+# loki-transform.py. The define the set of transformation and the
+# order in which they are applies to the complete call tree.
+[pipelines]
+
+[pipelines.idem]
+  transformations = ['Idem', 'ModuleWrap', 'Dependency']
+
+[pipelines.scc]
+  transformations = ['DataOffload', 'SCCVector', 'ModuleWrap', 'Dependency']
+
+[pipelines.scc-hoist]
+  transformations = ['DataOffload', 'SCCHoist', 'ModuleWrap', 'Dependency']


### PR DESCRIPTION
This PR updates the Loki usage by adding transformation pipeline definitions to the associated config files for each variant and removing the now deprecated options in the CMake invocation layer. This requires a small update to the Fortran module directory usage to avoid aliasing, as the newly generated module names now all get the same name across variants. This makes the dwarf compatible with the impending removal of the deprecated custom options in upstream Loki.

Please note that these changes do not introduce any new functionality, but merely are a like-for-like update to the current ones, following the template from the main CLOUDSC dwarf.