### PR TITLE
'cloudsc_loki.config' files: ignore 'parkind1'

### DIFF
--- a/src/cloudsc2_ad_loki/cloudsc_loki.config
+++ b/src/cloudsc2_ad_loki/cloudsc_loki.config
@@ -10,6 +10,7 @@ demote_locals = true
 # do not attempt to look up the source files for these.
 
 disable = ['timer_mod', 'file_io_mod', 'foe*', 'fes*', 'falfaad']
+ignore = ['parkind1']
 
 # Define entry point for call-tree transformation
 [routines]

--- a/src/cloudsc2_nl_loki/cloudsc_loki.config
+++ b/src/cloudsc2_nl_loki/cloudsc_loki.config
@@ -10,6 +10,7 @@ demote_locals = true
 # do not attempt to look up the source files for these.
 
 disable = ['timer_mod', 'file_io_mod', 'foe*']
+ignore = ['parkind1']
 
 # Define entry point for call-tree transformation
 [routines]

--- a/src/cloudsc2_tl_loki/cloudsc_loki.config
+++ b/src/cloudsc2_tl_loki/cloudsc_loki.config
@@ -10,6 +10,7 @@ demote_locals = true
 # do not attempt to look up the source files for these.
 
 disable = ['timer_mod', 'file_io_mod', 'error_mod', 'foe*', 'fes*']
+ignore = ['parkind1']
 
 # Define entry point for call-tree transformation
 [routines]


### PR DESCRIPTION
Recent Loki developments require relevant module processing.
In order to avoid the attempt to process an incomplete module, ignore `parkind1`.