### PR TITLE
CLOUDSC2: Update to using ecbuild 3.14.2 for usptream Loki testing

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -10,7 +10,7 @@ projects :
 
     - ecbuild :
         git     : https://github.com/ecmwf/ecbuild
-        version : 3.8.4
+        version : 3.14.2
         bundle  : false
 
     - loki :


### PR DESCRIPTION
### Description

This PR updates the bundle to ecbuild 3.14.2 to keep up with upstream Loki updates.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 